### PR TITLE
Support multiple domains & Terraform versions 1.2.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,19 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  validate:
+    name: Validate
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.2.3
+
+      - name: Init
+        run: terraform init
+
+      - name: Validate
+        run: terraform validate

--- a/locals.tf
+++ b/locals.tf
@@ -1,6 +1,4 @@
 locals {
-  has_domain       = var.domain != ""
-  domain           = local.has_domain ? var.domain : ""
   website_filepath = var.website_path
   app_name_default = "${var.app_name}-${var.environment}"
 

--- a/main.tf
+++ b/main.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "1.2.3"
+  required_version = "~> 1.2.3"
 
   required_providers {
     aws = {

--- a/modules/aws-static-website-configuration/acm.tf
+++ b/modules/aws-static-website-configuration/acm.tf
@@ -1,18 +1,18 @@
 resource "aws_acm_certificate" "this" {
-  count = var.domain != "" ? 1 : 0
+  count = length(var.domains) > 0 ? 1 : 0
 
   provider = aws.us-east-1
 
-  domain_name               = var.domain
+  domain_name               = var.domains[0]
   validation_method         = "DNS"
-  subject_alternative_names = ["*.${var.domain}"]
+  subject_alternative_names = [for d in var.domains : "*.${d}"]
 }
 
 resource "aws_acm_certificate_validation" "this" {
-  count = var.domain != "" ? 1 : 0
+  for_each = aws_acm_certificate.this
 
   provider = aws.us-east-1
 
-  certificate_arn         = aws_acm_certificate.this[0].arn
+  certificate_arn         = each.value.arn
   validation_record_fqdns = [for record in aws_route53_record.cert_validation : record.fqdn]
 }

--- a/modules/aws-static-website-configuration/outputs.tf
+++ b/modules/aws-static-website-configuration/outputs.tf
@@ -1,5 +1,5 @@
-output "website-url" {
-  value = var.domain != "" ? var.domain : aws_cloudfront_distribution.this.domain_name
+output "website-urls" {
+  value = length(var.domains) > 0 ? var.domains : aws_cloudfront_distribution.this.domain_name
 }
 
 output "bucket_logs" {

--- a/modules/aws-static-website-configuration/route53.tf
+++ b/modules/aws-static-website-configuration/route53.tf
@@ -1,15 +1,14 @@
-data "aws_route53_zone" "this" {
-  count = var.domain != "" ? 1 : 0
-
-  name = "${var.domain}."
+data "aws_route53_zone" "dns_zone" {
+  for_each = toset(var.domains)
+  name     = each.key
 }
 
 resource "aws_route53_record" "website" {
-  count = var.domain != "" ? 1 : 0
+  for_each = toset(var.domains)
 
-  name    = var.domain
+  name    = each.key
   type    = "A"
-  zone_id = data.aws_route53_zone.this[0].zone_id
+  zone_id = data.aws_route53_zone.dns_zone[each.key].zone_id
 
   alias {
     evaluate_target_health = false
@@ -23,11 +22,11 @@ resource "aws_route53_record" "website" {
 }
 
 resource "aws_route53_record" "www" {
-  count = var.domain != "" ? 1 : 0
+  for_each = toset(var.domains)
 
-  name    = "www.${var.domain}"
+  name    = "www.${each.key}"
   type    = "CNAME"
-  zone_id = data.aws_route53_zone.this[0].zone_id
+  zone_id = data.aws_route53_zone.dns_zone[each.key].zone_id
   ttl     = 300
 
   records = ["${aws_cloudfront_distribution.this.domain_name}"]
@@ -36,18 +35,19 @@ resource "aws_route53_record" "www" {
 resource "aws_route53_record" "cert_validation" {
   provider = aws.us-east-1
 
-  for_each = var.domain != "" ? {
-    for dvo in aws_acm_certificate.this[0].domain_validation_options : dvo.domain_name => {
-      name   = dvo.resource_record_name
-      record = dvo.resource_record_value
-      type   = dvo.resource_record_type
+  for_each = flatten([for d in var.domains : [
+    for dvo in aws_acm_certificate.this[0].domain_validation_options : {
+      zone_id = data.aws_route53_zone.dns_zone[d].zone_id
+      name    = dvo.resource_record_name
+      type    = dvo.resource_record_type
+      value   = dvo.resource_record_value
     }
-  } : {}
+  ]])
 
   allow_overwrite = true
   name            = each.value.name
   records         = [each.value.record]
   ttl             = 60
   type            = each.value.type
-  zone_id         = data.aws_route53_zone.this[0].zone_id
+  zone_id         = each.value.zone_id
 }

--- a/modules/aws-static-website-configuration/s3.tf
+++ b/modules/aws-static-website-configuration/s3.tf
@@ -18,7 +18,7 @@ data "aws_iam_policy_document" "s3_allow_access_from_cf" {
 
 resource "aws_s3_bucket" "logs" {
   bucket        = "${var.app_name_default}-logs"
-  force_destroy = !(var.domain != "")
+  force_destroy = var.domains == []
 
   tags = var.common_tags
 
@@ -31,7 +31,7 @@ resource "aws_s3_bucket_acl" "acl_logs" {
 
 resource "aws_s3_bucket" "website" {
   bucket        = var.app_name_default
-  force_destroy = !(var.domain != "")
+  force_destroy = var.domains == []
 
   tags = var.common_tags
 }

--- a/modules/aws-static-website-configuration/variables.tf
+++ b/modules/aws-static-website-configuration/variables.tf
@@ -3,10 +3,10 @@ variable "aws_profile" {
   description = ""
 }
 
-variable "domain" {
-  type        = string
-  description = ""
-  default     = ""
+variable "domains" {
+  type        = list(string)
+  description = "List of domains that will be used for the website."
+  default     = []
 }
 
 # https://github.com/hashicorp/terraform-template-dir/blob/master/variables.tf

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,5 @@
-output "website-url" {
-  value = module.website_s3_bucket.website-url
+output "website-urls" {
+  value = module.website_s3_bucket.website-urls
 }
 
 output "cdn-url" {

--- a/variables.tf
+++ b/variables.tf
@@ -10,10 +10,10 @@ variable "aws_profile" {
   default     = "viniciustrainotti"
 }
 
-variable "domain" {
-  type        = string
-  description = ""
-  default     = ""
+variable "domains" {
+  type        = list(string)
+  description = "List of domains that will be used for the website."
+  default     = []
 }
 
 variable "environment" {

--- a/website.tf
+++ b/website.tf
@@ -2,7 +2,7 @@ module "website_s3_bucket" {
   source = "./modules/aws-static-website-configuration"
 
   aws_profile      = var.aws_profile
-  domain           = var.domain
+  domains          = var.domains
   app_name_default = local.app_name_default
   website_path     = var.website_path
 


### PR DESCRIPTION
These (untested) changes make it so the Terraform configuration can support
multiple domain names. While the existence of such a use case can be debated,
it's added in an attempt to generalize this module as much as possible and
expand its usefulness.

Additionally, all Terraform versions 1.2.x are accepted after 03035c4.

A CI workflow to run `terraform validate` was added in 702ee60.
