### PR TITLE
Support Terraform versions 1.x

### DIFF
--- a/versions.tf
+++ b/versions.tf
@@ -1,5 +1,5 @@
 terraform {
-  required_version = "~> 1.2.3"
+  required_version = ">= 1.2.3, < 2.0.0"
 
   required_providers {
     aws = {


### PR DESCRIPTION
Considering the compatibility promises of Terraform v1.x and the features used in this module, it's a good idea to support all versions leading up to, but not including, 2.0.0, for whenever it is released.

More about Terraform v1.x compatibility: https://www.terraform.io/language/v1-compatibility-promises
